### PR TITLE
Feature/2 episode sortable report

### DIFF
--- a/ahcer/src/app/app-routing.module.ts
+++ b/ahcer/src/app/app-routing.module.ts
@@ -13,6 +13,7 @@ import {redirectUnauthorizedTo} from "@angular/fire/auth-guard";
 import { canActivate } from '@angular/fire/compat/auth-guard';
 import {HelpComponent} from "./help/help.component";
 import { UserIdResolver } from "./services/user-id.resolver";
+import {EpisodeReportComponent} from "./episode-report/episode-report.component";
 
 
 
@@ -79,11 +80,14 @@ const routes: Routes = [
     component: ViewEpisodesComponent,
     ...canActivate(redirectUnauthorizedToLogin)
   },
-
-
   {
     path: 'medications',
     component: ViewMedicationComponent,
+    ...canActivate(redirectUnauthorizedToLogin)
+  },
+  {
+    path: 'episode-report',
+    component: EpisodeReportComponent,
    ...canActivate(redirectUnauthorizedToLogin)
   }
 ];

--- a/ahcer/src/app/app.component.html
+++ b/ahcer/src/app/app.component.html
@@ -37,7 +37,7 @@
         <span> Manage Medications</span>
       </a>
 
-      <a mat-list-item  *ngIf="user.isLoggedIn$ | async">
+      <a mat-list-item routerLink="episode-report" *ngIf="user.isLoggedIn$ | async">
 
         <mat-icon>library_books</mat-icon>
 

--- a/ahcer/src/app/app.component.html
+++ b/ahcer/src/app/app.component.html
@@ -1,68 +1,6 @@
-
-
-<mat-sidenav-container fullscreen>
-
-  <mat-sidenav #start (click)= "start.close()">
-
-    <mat-nav-list>
-      <a mat-list-item routerLink="/" *ngIf="user.isLoggedIn$ | async">
-        <mat-icon>home</mat-icon>
-        <span> Home</span>
-      </a>
-      <a mat-list-item routerLink="login" *ngIf="user.isLoggedOut$ | async">
-
-        <mat-icon>account_circle</mat-icon>
-
-        <span> Login</span>
-      </a>
-
-      <a mat-list-item routerLink="/record-episode" *ngIf="user.isLoggedIn$ | async">
-
-        <mat-icon>emergency_recording</mat-icon>
-
-        <span> Record Episodes</span>
-      </a>
-
-      <a mat-list-item routerLink="patients" *ngIf="user.isLoggedIn$ | async">
-
-        <mat-icon>account_circle</mat-icon>
-
-        <span> View Patients</span>
-      </a>
-
-      <a mat-list-item routerLink="medications" *ngIf="user.isLoggedIn$ | async">
-
-        <mat-icon>vaccines</mat-icon>
-
-        <span> Manage Medications</span>
-      </a>
-
-      <a mat-list-item routerLink="episode-report" *ngIf="user.isLoggedIn$ | async">
-
-        <mat-icon>library_books</mat-icon>
-
-        <span> Reports</span>
-      </a>
-
-      <a mat-list-item routerLink="help" *ngIf="user.isLoggedIn$ | async">
-        <mat-icon>help</mat-icon>
-        <span> Help</span>
-      </a>
-
-      <a mat-list-item routerLink="about">
-        <mat-icon>info</mat-icon>
-        <span> About</span>
-      </a>
-
-      <a mat-list-item (click)="logout()"  *ngIf="user.isLoggedIn$ | async">
-        <mat-icon>logout</mat-icon>
-        <span> Log Out</span>
-      </a>
-    </mat-nav-list>
-  </mat-sidenav>
-
+<div class="container">
   <mat-toolbar color="primary" class="nav-bar">
-    <button mat-icon-button (click)="start.open('mouse')">
+    <button mat-icon-button (click)="start.toggle()">
       <mat-icon>menu</mat-icon>
     </button>
     <img src="/assets/img/large_e.png" class="menu-logo" alt="E Logo"><span>AHC Episode App</span>
@@ -70,19 +8,82 @@
       <a routerLink="view-profile">
         <img alt="View Profile"
              [src]="(user.pictureUrl$ | async)?
-                    (user.pictureUrl$ | async) :
-                    '../assets/img/default-profile-pic.jpg'"/>
+                      (user.pictureUrl$ | async) :
+                      '../assets/img/default-profile-pic.jpg'"/>
       </a>
     </div>
   </mat-toolbar>
-  <div class="container">
-    <router-outlet></router-outlet>
-  </div>
-  <mat-toolbar color="primary" class="footer">
-    <span class="footer-spacer">AHCER-App &copy; 2022 - V {{version}}</span>
-  </mat-toolbar>
-</mat-sidenav-container>
 
+  <mat-sidenav-container class="sidenav-container">
+
+    <mat-sidenav #start (click)= "start.close()">
+
+      <mat-nav-list>
+        <a mat-list-item routerLink="/" *ngIf="user.isLoggedIn$ | async">
+          <mat-icon>home</mat-icon>
+          <span> Home</span>
+        </a>
+        <a mat-list-item routerLink="login" *ngIf="user.isLoggedOut$ | async">
+
+          <mat-icon>account_circle</mat-icon>
+
+          <span> Login</span>
+        </a>
+
+        <a mat-list-item routerLink="/record-episode" *ngIf="user.isLoggedIn$ | async">
+
+          <mat-icon>emergency_recording</mat-icon>
+
+          <span> Record Episodes</span>
+        </a>
+
+        <a mat-list-item routerLink="patients" *ngIf="user.isLoggedIn$ | async">
+
+          <mat-icon>account_circle</mat-icon>
+
+          <span> View Patients</span>
+        </a>
+
+        <a mat-list-item routerLink="medications" *ngIf="user.isLoggedIn$ | async">
+
+          <mat-icon>vaccines</mat-icon>
+
+          <span> Manage Medications</span>
+        </a>
+
+        <a mat-list-item routerLink="episode-report" *ngIf="user.isLoggedIn$ | async">
+
+          <mat-icon>library_books</mat-icon>
+
+          <span> Reports</span>
+        </a>
+
+        <a mat-list-item routerLink="help" *ngIf="user.isLoggedIn$ | async">
+          <mat-icon>help</mat-icon>
+          <span> Help</span>
+        </a>
+
+        <a mat-list-item routerLink="about">
+          <mat-icon>info</mat-icon>
+          <span> About</span>
+        </a>
+
+        <a mat-list-item (click)="logout()"  *ngIf="user.isLoggedIn$ | async">
+          <mat-icon>logout</mat-icon>
+          <span> Log Out</span>
+        </a>
+      </mat-nav-list>
+    </mat-sidenav>
+
+
+    <div class="content-container">
+      <router-outlet></router-outlet>
+    </div>
+    <mat-toolbar color="primary" class="footer">
+      <span class="footer-spacer">AHCER-App &copy; 2022 - V {{version}}</span>
+    </mat-toolbar>
+  </mat-sidenav-container>
+</div>
 
 
 

--- a/ahcer/src/app/app.component.scss
+++ b/ahcer/src/app/app.component.scss
@@ -1,8 +1,19 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+}
+
 .footer {
   width: 100%;
   text-align: center;
   color: black;
 }
+
 .footer-spacer {
   flex: 1 1 auto;
 }
@@ -12,14 +23,18 @@
   margin:0 10px;
 }
 
-.container {
+.content-container {
   min-height: calc(100vh - 148px);
 }
 
 @media only screen and (max-width: 600px) {
-  .container {
+  .content-container {
     min-height: calc(100vh - 112px);
   }
+}
+
+.sidenav-container {
+  flex: 1;
 }
 
 .user-icon {
@@ -42,6 +57,16 @@
   position: -webkit-sticky; /* For macOS/iOS Safari */
   top: 0; /* Sets the sticky toolbar to be on top */
   z-index: 1000; /* Ensure that your app's content doesn't overlap the toolbar */
+}
+
+@media print {
+  .container {
+    bottom: unset;
+  }
+
+  .nav-bar, .footer {
+    display: none;
+  }
 }
 
 

--- a/ahcer/src/app/app.module.ts
+++ b/ahcer/src/app/app.module.ts
@@ -51,6 +51,10 @@ import {MatRadioModule} from "@angular/material/radio";
 import {NgxMaskModule} from "ngx-mask";
 import { HelpComponent } from './help/help.component';
 import { QuillModule } from 'ngx-quill';
+import { EpisodeReportComponent } from './episode-report/episode-report.component';
+import {MatTooltipModule} from "@angular/material/tooltip";
+import {MatSortModule} from "@angular/material/sort";
+import {MatPaginatorModule} from "@angular/material/paginator";
 
 @NgModule({
   declarations: [
@@ -72,7 +76,8 @@ import { QuillModule } from 'ngx-quill';
     ViewMedicationComponent,
     CreateMedicationComponent,
     EditMedicationComponent,
-    HelpComponent
+    HelpComponent,
+    EpisodeReportComponent
   ],
   imports: [
     BrowserModule,
@@ -103,7 +108,10 @@ import { QuillModule } from 'ngx-quill';
     MatSlideToggleModule,
     QuillModule,
     MatRadioModule,
-    NgxMaskModule.forRoot()
+    NgxMaskModule.forRoot(),
+    MatTooltipModule,
+    MatSortModule,
+    MatPaginatorModule
   ],
   providers: [
     ScreenTrackingService,UserTrackingService, PatientServices, UsersService

--- a/ahcer/src/app/episode-report/episode-report.component.html
+++ b/ahcer/src/app/episode-report/episode-report.component.html
@@ -1,0 +1,104 @@
+<div class="component-container">
+  <h2 class="header" *ngIf="!loadingPatient && currentPatient">
+    Complete episode list for {{currentPatient.firstName}} {{currentPatient.lastName}}
+  </h2>
+  <p *ngIf="!loadingPatient && !currentPatient">No patients found. Please add one.</p>
+
+  <mat-form-field appearance="fill" *ngIf="patients && patients.length > 1">
+    <mat-label>Choose a different patient</mat-label>
+    <mat-select (selectionChange)="changePatient($event.value)">
+      <mat-option *ngFor="let patient of patients" [value]="patient.id">{{patient.firstName}}</mat-option>
+    </mat-select>
+  </mat-form-field>
+  <div class="table-container mat-elevation-z8" *ngIf="episodes_count > 0" >
+    <table mat-table [dataSource]="dataSource" matSort>
+
+      <ng-container matColumnDef="startTime">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> Start Date </th>
+        <td mat-cell *matCellDef="let element"> {{element.startTime?.toDate()| date: 'MM/dd/yyyy'}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="endTime">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> End Date </th>
+        <td mat-cell *matCellDef="let element"> {{element.endTime?.toDate()| date: 'MM/dd/yyyy'}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="duration">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Duration</th>
+        <td mat-cell *matCellDef="let result">{{calculateDuration(result.startTime, result.endTime)}}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="symptoms">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Symptoms</th>
+        <td mat-cell *matCellDef="let result">
+          <span class="long-text-container">
+            <span class="long-text" #symptoms>
+              {{displaySymptomsString(result.symptoms)}}
+            </span>
+            <mat-icon *ngIf="(symptoms.innerText.slice(-3)=='...')"
+                      [matTooltip]="displaySymptomsString(result.symptoms, true)">
+              expand_circle_down
+            </mat-icon>
+          </span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="rescueMeds">
+        <th mat-header-cell *matHeaderCellDef>Rescue Meds</th>
+        <td mat-cell *matCellDef="let result">
+          <span class="long-text-container">
+            <span class="long-text" #rescueMeds>
+              {{displayRescueMedsString(result.medications?.rescueMeds)}}
+            </span>
+            <mat-icon *ngIf="(rescueMeds.innerText.slice(-3)=='...')"
+                      [matTooltip]="displayRescueMedsString(result.medications?.rescueMeds, true)">
+              expand_circle_down
+            </mat-icon>
+          </span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="prescriptionMeds">
+        <th mat-header-cell *matHeaderCellDef>Prescription Meds</th>
+        <td mat-cell *matCellDef="let result">
+          <span class="long-text-container">
+            <span class="long-text" #rescueMeds>
+              {{displayPrescriptionMedsString(result.medications?.prescriptionMeds)}}
+            </span>
+            <mat-icon *ngIf="(rescueMeds.innerText.slice(-3)=='...')"
+                      [matTooltip]="displayPrescriptionMedsString(
+                        result.medications?.prescriptionMeds,
+                        true)">
+              expand_circle_down
+            </mat-icon>
+          </span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="triggers">
+        <th mat-header-cell *matHeaderCellDef>Triggers</th>
+        <td mat-cell *matCellDef="let result">
+          <span class="long-text-container">
+            <span class="long-text" #rescueMeds>
+              {{displayTriggersString(result.knownTriggers, result.otherTrigger)}}
+            </span>
+            <mat-icon *ngIf="(rescueMeds.innerText.slice(-3)=='...')"
+                      [matTooltip]="displayTriggersString(result.knownTriggers,
+                                                          result.otherTrigger,
+                                                          true)">
+              expand_circle_down
+            </mat-icon>
+          </span>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+    <mat-paginator [pageSizeOptions]="[10, 20, 40]" showFirstLastButtons></mat-paginator>
+  </div>
+  <div *ngIf="episodes_count === 0">No episodes found.</div>
+</div>
+<div class="spinner-container" *ngIf="loadingPatient || loadingEpisodes">
+  <mat-spinner [diameter]="100"></mat-spinner>
+</div>

--- a/ahcer/src/app/episode-report/episode-report.component.html
+++ b/ahcer/src/app/episode-report/episode-report.component.html
@@ -1,10 +1,11 @@
 <div class="component-container">
   <h2 class="header" *ngIf="!loadingPatient && currentPatient">
-    Complete episode list for {{currentPatient.firstName}} {{currentPatient.lastName}}
+    Complete episode list
+    <span class="not-printable"> for {{currentPatient.firstName}} {{currentPatient.lastName}}</span>
   </h2>
   <p *ngIf="!loadingPatient && !currentPatient">No patients found. Please add one.</p>
 
-  <mat-form-field appearance="fill" *ngIf="patients && patients.length > 1">
+  <mat-form-field appearance="fill" class="not-printable" *ngIf="patients && patients.length > 1">
     <mat-label>Choose a different patient</mat-label>
     <mat-select (selectionChange)="changePatient($event.value)">
       <mat-option *ngFor="let patient of patients" [value]="patient.id">{{patient.firstName}}</mat-option>
@@ -31,7 +32,7 @@
       <ng-container matColumnDef="symptoms">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Symptoms</th>
         <td mat-cell *matCellDef="let result">
-          <span class="long-text-container">
+          <span class="long-text-container not-printable">
             <span class="long-text" #symptoms>
               {{displaySymptomsString(result.symptoms)}}
             </span>
@@ -40,13 +41,18 @@
               expand_circle_down
             </mat-icon>
           </span>
+          <span class="long-text-container print-only">
+            <span class="long-text">
+              {{displaySymptomsString(result.symptoms, true)}}
+            </span>
+          </span>
         </td>
       </ng-container>
 
       <ng-container matColumnDef="rescueMeds">
         <th mat-header-cell *matHeaderCellDef>Rescue Meds</th>
         <td mat-cell *matCellDef="let result">
-          <span class="long-text-container">
+          <span class="long-text-container not-printable">
             <span class="long-text" #rescueMeds>
               {{displayRescueMedsString(result.medications?.rescueMeds)}}
             </span>
@@ -55,13 +61,18 @@
               expand_circle_down
             </mat-icon>
           </span>
+          <span class="long-text-container print-only">
+            <span class="long-text">
+              {{displayRescueMedsString(result.medications?.rescueMeds, true)}}
+            </span>
+          </span>
         </td>
       </ng-container>
 
       <ng-container matColumnDef="prescriptionMeds">
         <th mat-header-cell *matHeaderCellDef>Prescription Meds</th>
         <td mat-cell *matCellDef="let result">
-          <span class="long-text-container">
+          <span class="long-text-container not-printable">
             <span class="long-text" #rescueMeds>
               {{displayPrescriptionMedsString(result.medications?.prescriptionMeds)}}
             </span>
@@ -72,13 +83,18 @@
               expand_circle_down
             </mat-icon>
           </span>
+          <span class="long-text-container print-only">
+            <span class="long-text">
+              {{displayPrescriptionMedsString(result.medications?.prescriptionMeds, true)}}
+            </span>
+          </span>
         </td>
       </ng-container>
 
       <ng-container matColumnDef="triggers">
         <th mat-header-cell *matHeaderCellDef>Triggers</th>
         <td mat-cell *matCellDef="let result">
-          <span class="long-text-container">
+          <span class="long-text-container not-printable">
             <span class="long-text" #rescueMeds>
               {{displayTriggersString(result.knownTriggers, result.otherTrigger)}}
             </span>
@@ -89,13 +105,18 @@
               expand_circle_down
             </mat-icon>
           </span>
+          <span class="long-text-container print-only">
+            <span class="long-text">
+              {{displayTriggersString(result.knownTriggers, result.otherTrigger, true)}}
+            </span>
+          </span>
         </td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
-    <mat-paginator [pageSizeOptions]="[10, 20, 40]" showFirstLastButtons></mat-paginator>
+    <mat-paginator [pageSizeOptions]="[10, 20, 40]" showFirstLastButtons class="not-printable"></mat-paginator>
   </div>
   <div *ngIf="episodes_count === 0">No episodes found.</div>
 </div>

--- a/ahcer/src/app/episode-report/episode-report.component.scss
+++ b/ahcer/src/app/episode-report/episode-report.component.scss
@@ -36,10 +36,6 @@
   justify-content: center;
 }
 
-.invisible {
-  visibility: hidden;
-}
-
 .spinner-container {
   height: 100vh;
   width: 100vw;
@@ -59,4 +55,22 @@
 .mat-cell, .mat-header-cell, .mat-footer-cell {
   padding-right: 5px;
   padding-left: 5px;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.print-only {
+  display: none;
+}
+
+@media print {
+  .print-only {
+    display: unset;
+  }
+
+  .not-printable {
+    display: none;
+  }
 }

--- a/ahcer/src/app/episode-report/episode-report.component.scss
+++ b/ahcer/src/app/episode-report/episode-report.component.scss
@@ -1,0 +1,62 @@
+@media only screen and (min-width:1000px) {
+  .component-container {
+    max-width: 90vw;
+    margin: 20px auto 20px auto;
+  }
+
+  table {
+    width: 100%;
+  }
+}
+
+@media only screen and (max-width:1000px) {
+  .component-container {
+    margin: 20px 10px 20px 10px;
+  }
+
+  .table-container {
+    overflow-x: scroll;
+  }
+
+  table {
+    width: 1000px;
+  }
+}
+
+.long-text-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 5px;
+}
+
+.long-text {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.spinner-container {
+  height: 100vh;
+  width: 100vw;
+  position: fixed;
+  left: 0;
+  top: 0;
+  vertical-align: center;
+}
+
+.spinner-container mat-spinner {
+  margin: 0;
+  position: absolute;
+  top: calc(50% - 50px);
+  left: calc(50% - 50px);
+}
+
+.mat-cell, .mat-header-cell, .mat-footer-cell {
+  padding-right: 5px;
+  padding-left: 5px;
+}

--- a/ahcer/src/app/episode-report/episode-report.component.spec.ts
+++ b/ahcer/src/app/episode-report/episode-report.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EpisodeReportComponent } from './episode-report.component';
+
+describe('EpisodeReportComponent', () => {
+  let component: EpisodeReportComponent;
+  let fixture: ComponentFixture<EpisodeReportComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EpisodeReportComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EpisodeReportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ahcer/src/app/episode-report/episode-report.component.ts
+++ b/ahcer/src/app/episode-report/episode-report.component.ts
@@ -1,0 +1,270 @@
+import {AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
+import {Episode} from "../models/episode";
+import {Patient} from "../models/patient";
+import {EpisodeService} from "../services/episode.service";
+import {PatientServices} from "../services/patient.service";
+import {UsersService} from "../services/users.service";
+import {finalize} from "rxjs";
+import firebase from "firebase/compat";
+import Timestamp = firebase.firestore.Timestamp;
+import {MedicationService} from "../services/medication.service";
+import {MatTableDataSource} from "@angular/material/table";
+import {MatSort} from "@angular/material/sort";
+import {MatPaginator} from "@angular/material/paginator";
+
+@Component({
+  selector: 'app-episode-report',
+  templateUrl: './episode-report.component.html',
+  styleUrls: ['./episode-report.component.scss']
+})
+export class EpisodeReportComponent implements OnInit, AfterViewInit {
+
+  displayedColumns: string[] = ['startTime', 'endTime', 'duration', 'symptoms',
+                                'rescueMeds', 'prescriptionMeds', 'triggers'];
+  loadingPatient: boolean = false;
+  loadingEpisodes: boolean = false;
+  loadingRescueMeds: boolean = false;
+  episodes: Episode[]=[];
+  patients: Patient[];
+  rescueMedNames: Object = {};
+  currentPatient : Patient;
+  episodes_count: number;
+  dataSource: MatTableDataSource<Episode> = new MatTableDataSource<Episode>();
+
+  constructor(private medicationService: MedicationService,
+              private episodeService: EpisodeService,
+              private patientsService: PatientServices,
+              private usersService: UsersService) { }
+
+  ngOnInit(): void {
+    this.loadingPatient = true;
+
+    this.patientsService.getPatients().subscribe(
+      patients => {this.patients = patients}
+    )
+    this.usersService.getLastViewedPatient().subscribe(
+      (patientId)  => {
+        if(patientId) {
+          this.loadPatient(patientId);
+          this.loadEpisodes(patientId);
+          this.loadRescueMeds(patientId);
+        }
+        else {
+          this.loadingPatient = false;
+        }
+      })
+  }
+
+  @ViewChild(MatSort) sort: MatSort;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  sortingDataAccessor = (item: Episode, property: string) => {
+    switch (property) {
+      case 'startTime':
+        return item.startTime.seconds;
+      case 'endTime':
+        return item.endTime?.seconds;
+      case 'duration':
+        return (item.endTime)? item.endTime.seconds - item.startTime.seconds: null;
+      case 'symptoms':
+        return this.displaySymptomsString(item.symptoms);
+      default:
+        return item[property];
+    }
+  }
+
+  reloadDataSource() {
+    this.dataSource.data = this.episodes;
+    this.dataSource.sort = this.sort;
+    this.dataSource.sortingDataAccessor = this.sortingDataAccessor;
+    this.dataSource.paginator = this.paginator;
+  }
+
+  ngAfterViewInit() {
+    this.reloadDataSource();
+  }
+
+  loadEpisodes(patientId: string) {
+    this.loadingEpisodes = true;
+    this.episodeService.getAllEpisodesByPatient(patientId, 'desc')
+      .pipe(
+        finalize(() => {
+          this.loadingEpisodes = false;
+          this.episodes_count = this.episodes.length;
+          this.reloadDataSource();
+        })
+      )
+      .subscribe(
+        episodes => {this.episodes = episodes}
+      );
+  }
+
+  changePatient(patientId: string) {
+    this.usersService.changeLastViewedPatient(patientId)
+      .subscribe(()=> {
+        this.loadPatient(patientId)
+      })
+  }
+
+  loadPatient(patientId: string) {
+    if(patientId == this.currentPatient?.id) {
+      return
+    }
+    this.patientsService.getPatientById(patientId)
+      .pipe(
+        finalize(()=> this.loadingPatient = false)
+      )
+      .subscribe(patient => {
+        this.currentPatient = patient;
+        this.loadEpisodes(patientId);
+        this.loadRescueMeds(patientId);
+      })
+  }
+
+  loadRescueMeds(patientId: string) {
+    this.loadingRescueMeds = true;
+    this.medicationService.getMedicationsByType(patientId, true,  false, false)
+      .pipe(
+        finalize(()=> this.loadingRescueMeds=false)
+      ).subscribe(medications => {
+        for(let med of medications) {
+          this.rescueMedNames[med.id] = med.name;
+        }
+      })
+  }
+
+  calculateDuration(startTime: Timestamp, endTime: Timestamp) {
+    return this.episodeService.calculateDuration(startTime, endTime);
+  }
+
+  //needs rework when symptom management is implemented
+  displaySymptomsString(symptoms: Episode["symptoms"], showFullList: boolean = false): string {
+    if (!symptoms) {
+      return "";
+    }
+    let symptomTexts = ["Full Body", "Left Arm", "Right Arm", "Left Leg", "Right Leg",
+      "Left Hand", "Right Hand", "Eyes", "Loss of Consciousness", "Seizure"];
+    let symptomKeys = ["fullBody", "leftArm", "rightArm", "leftLeg", "rightLeg",
+      "leftHand", "rightHand", "eyes", "lossOfConsciousness", "seizure"];
+    let symptomStr = "";
+    let numSymptoms = 0;
+    for (let index in symptomKeys) {
+      let symptomText = ""
+      if(symptoms[symptomKeys[index]]) {
+        if(!showFullList && numSymptoms == 2) {
+          symptomStr +=", ...";
+          break;
+        }
+
+        if(symptomKeys[index]=="lossOfConsciousness" || symptomKeys[index]=="seizure") {
+          symptomText = symptomTexts[index];
+        }
+        else {
+          symptomText = symptomTexts[index];
+          symptomText += ` (${symptoms[symptomKeys[index]]})`;
+        }
+
+        if(numSymptoms == 0) {
+          symptomStr = symptomText;
+        }
+        else if(numSymptoms > 0) {
+          symptomStr += `, ${symptomText}`;
+        }
+        numSymptoms++;
+      }
+    }
+    return symptomStr;
+  }
+
+  //needs rework when timestamp for rescue meds is implemented
+  displayRescueMedsString(rescueMeds: Episode["medications"]["rescueMeds"],
+                          showFullList: boolean = false): string {
+    if(!rescueMeds || rescueMeds.length<=0) {
+      return "";
+    }
+
+    let numMeds = 0;
+    let medsStr = "";
+    for(let med of rescueMeds) {
+      if (!showFullList && numMeds >= 2) {
+        medsStr += ", ...";
+        break;
+      }
+      if(numMeds == 0) {
+        medsStr = this.rescueMedNames[med.id];
+      }
+      else {
+        medsStr += `, ${this.rescueMedNames[med.id]}`;
+      }
+      numMeds++;
+    }
+    return medsStr;
+  }
+
+  displayPrescriptionMedsString(prescriptionMeds: Episode['medications']['prescriptionMeds'],
+                                showFullList: boolean = false): string {
+    if(!prescriptionMeds || prescriptionMeds.length <= 0) {
+      return "";
+    }
+
+    let numMeds = 0;
+    let medsStr = "";
+    for(let med of prescriptionMeds) {
+      if (!showFullList && numMeds >= 2) {
+        medsStr += ", ...";
+        break;
+      }
+      if(numMeds == 0) {
+        medsStr = med.name;
+      }
+      else {
+        medsStr += `, ${med.name}`;
+      }
+      numMeds++;
+    }
+    return medsStr;
+  }
+
+  displayTriggersString(triggers: Episode['knownTriggers'],
+                        additionalTriggers: Episode['otherTrigger'],
+                        showFullList: boolean = false): string {
+    if(!(triggers || additionalTriggers) || triggers.length <= 0 || triggers[0]=='') {
+      return "";
+    }
+
+    let numTriggers = 0;
+    let triggersStr = "";
+    for (let trigger of triggers) {
+      if (!showFullList && numTriggers >= 2) {
+        numTriggers ++;
+        triggersStr += ", ...";
+        break;
+      }
+      if (numTriggers == 0)
+        triggersStr = trigger;
+      else
+        triggersStr += `, ${trigger}`;
+      numTriggers++;
+    }
+    if(additionalTriggers) {
+      if(showFullList)
+        triggersStr += `, ${additionalTriggers}`;
+      else if (numTriggers == 2) {
+        triggersStr += ", ...";
+      }
+      else if (numTriggers < 2) {
+        let words = additionalTriggers.split(" ");
+        triggersStr +=","
+        for (let index = 0; index<words.length; index++) {
+          if(index > 1) {
+            triggersStr +=" ..."
+            break;
+          }
+          triggersStr += ` ${words[index]}`
+        }
+      }
+    }
+    return triggersStr;
+  }
+}
+

--- a/ahcer/src/app/episode-report/episode-report.component.ts
+++ b/ahcer/src/app/episode-report/episode-report.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, HostListener, OnInit, ViewChild} from '@angular/core';
 import {Episode} from "../models/episode";
 import {Patient} from "../models/patient";
 import {EpisodeService} from "../services/episode.service";
@@ -78,6 +78,19 @@ export class EpisodeReportComponent implements OnInit, AfterViewInit {
     this.dataSource.sort = this.sort;
     this.dataSource.sortingDataAccessor = this.sortingDataAccessor;
     this.dataSource.paginator = this.paginator;
+  }
+
+  @HostListener('window:beforeprint',['$event'])
+  onBeforePrint(event){
+    this.dataSource.data = this.episodes;
+    this.dataSource.sort = this.sort;
+    this.dataSource.sortingDataAccessor = this.sortingDataAccessor;
+    this.dataSource.paginator = null;
+  }
+
+  @HostListener('window:afterprint', ['$event'])
+  onAfterPrint(event) {
+    this.reloadDataSource();
   }
 
   ngAfterViewInit() {

--- a/ahcer/src/app/services/episode.service.ts
+++ b/ahcer/src/app/services/episode.service.ts
@@ -93,4 +93,55 @@ export class EpisodeService {
       first()
     );
   }
+
+  calculateDuration(startTime: Timestamp, endTime: Timestamp) {
+    if (endTime) {
+      let time = endTime.seconds - startTime.seconds
+      let day = Math.floor(time / (24 * 3600))
+      time = time % (24 * 3600)
+      let hour = Math.floor(time / 3600)
+      time %= 3600
+      let minutes = Math.floor(time / 60)
+      time %= 60
+      let seconds = time
+      if (day > 0) {
+        if (minutes >= 30) {
+          hour += 1
+          if (hour == 24) {
+            day += 1
+            hour = 0
+          }
+        }
+        return `${day} days ${hour} hrs`
+      }
+
+      else if (hour > 0) {
+        if (seconds >= 30) {
+          minutes += 1
+          if (minutes == 60) {
+            hour += 1
+            minutes = 0
+          }
+        }
+        if (hour == 24) {
+          day += 1
+          hour = 0
+          return `${day} days ${hour} hrs`
+        }
+        else {
+          return `${hour} hrs ${minutes} mins`
+        }
+      }
+
+      else if (minutes > 0) {
+        return `${minutes} mins ${seconds} secs`
+      }
+      else {
+        return `${seconds} secs`
+      }
+    }
+    else {
+      return null;
+    }
+  }
 }

--- a/ahcer/src/app/services/episode.service.ts
+++ b/ahcer/src/app/services/episode.service.ts
@@ -49,9 +49,9 @@ export class EpisodeService {
     );
   }
 
-  getEpisodesByPatient(patientId: string,
-                       sortOrder: OrderByDirection,
-                       lastStartTime?: Timestamp): Observable<Episode[]> {
+  get20EpisodesByPatient(patientId: string,
+                         sortOrder: OrderByDirection,
+                         lastStartTime?: Timestamp): Observable<Episode[]> {
     if (lastStartTime) {
       return this.user.userId$.pipe(
           switchMap(userId =>
@@ -72,6 +72,18 @@ export class EpisodeService {
           map(snaps => convertSnaps<Episode>(snaps))
         )
     }
+  }
+
+  getAllEpisodesByPatient(patientId: string,
+                          sortOrder: OrderByDirection) : Observable<Episode[]> {
+    return this.user.userId$.pipe(
+      switchMap(userId =>
+        this.db.collection(`users/${userId}/patients/${patientId}/episodes`,
+          ref => ref.orderBy('startTime', sortOrder))
+          .get()),
+      first(),
+      map(snaps => convertSnaps<Episode>(snaps))
+    )
   }
 
   updateEpisode(patientId: string, episodeId: string, changes: Partial<Patient>): Observable<any> {

--- a/ahcer/src/app/view-episodes/view-episodes.component.ts
+++ b/ahcer/src/app/view-episodes/view-episodes.component.ts
@@ -81,54 +81,7 @@ export class ViewEpisodesComponent implements OnInit {
   }
 
   calculateDuration(startTime: Timestamp, endTime: Timestamp) {
-    if (endTime) {
-      let time = endTime.seconds - startTime.seconds
-      let day = Math.floor(time / (24 * 3600))
-      time = time % (24 * 3600)
-      let hour = Math.floor(time / 3600)
-      time %= 3600
-      let minutes = Math.floor(time / 60)
-      time %= 60
-      let seconds = time
-      if (day > 0) {
-        if (minutes >= 30) {
-          hour += 1
-          if (hour == 24) {
-            day += 1
-            hour = 0
-          }
-        }
-        return `${day} days ${hour} hrs`
-      }
-
-      else if (hour > 0) {
-        if (seconds >= 30) {
-          minutes += 1
-          if (minutes == 60) {
-            hour += 1
-            minutes = 0
-          }
-        }
-        if (hour == 24) {
-          day += 1
-          hour = 0
-          return `${day} days ${hour} hrs`
-        }
-        else {
-          return `${hour} hrs ${minutes} mins`
-        }
-      }
-
-      else if (minutes > 0) {
-        return `${minutes} mins ${seconds} secs`
-      }
-      else {
-        return `${seconds} secs`
-      }
-    }
-    else {
-      return null;
-    }
+    return this.episodeServices.calculateDuration(startTime, endTime);
   }
 
   onViewDetails(episode:Episode) {

--- a/ahcer/src/app/view-episodes/view-episodes.component.ts
+++ b/ahcer/src/app/view-episodes/view-episodes.component.ts
@@ -42,7 +42,7 @@ export class ViewEpisodesComponent implements OnInit {
     this.usersService.getLastViewedPatient().pipe(
       switchMap(patientId => {
         this.patientId = patientId;
-        return this.episodeServices.getEpisodesByPatient(this.patientId, 'desc')
+        return this.episodeServices.get20EpisodesByPatient(this.patientId, 'desc')
       }),
       first(),
       finalize(() => {
@@ -64,7 +64,7 @@ export class ViewEpisodesComponent implements OnInit {
     this.lastPageLoaded++;
     this.loading = true;
 
-    this.episodeServices.getEpisodesByPatient(this.patientId,
+    this.episodeServices.get20EpisodesByPatient(this.patientId,
       'desc', this.lastStartTime)
       .pipe(
         finalize(() => {

--- a/ahcer/src/index.html
+++ b/ahcer/src/index.html
@@ -15,7 +15,7 @@
   <meta name="theme-color" content="#ffffff">
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/quill/1.3.6/quill.snow.min.css">
 </head>
 <body>


### PR DESCRIPTION
### What I changed/added
I added a report screen for episodes. The page will list all the episodes with details. The page is also printer-friendly and will list everything that has been shortened, and all the episodes will also be listed in print. 
I also changed the sidenav slightly, so the header now covers the sidenav.

### How to test
Click on the "Reports" menu in sidenav, check the episodes, hover over the arrow circle and see if every details are shown, Ctrl+P on windows or Command+P on Mac and see if the details are there.

### Questions I have
- Should I add a transparent overlay for small screen devices (less than 1000px screen width) to warn users that the screen won't look nice on their device? They would be able to click anywhere on the screen to dismiss the overlay.
- Should I add doses to the med details in the table? It would look similar to this: `Rescue Inhaler (200 ml), Tylenor (1 caps)`.
