### PR TITLE
Feature/27 adaptive page title

### DIFF
--- a/ahcer/src/app/app-routing.module.ts
+++ b/ahcer/src/app/app-routing.module.ts
@@ -94,6 +94,10 @@ const routes: Routes = [
     path: 'privacy-policy',
     component: PrivacyPolicyComponent,
     ...customPayload("Privacy Policy")
+  },
+  {
+    path: '**',
+    redirectTo: ''
   }
 ];
 

--- a/ahcer/src/app/app-routing.module.ts
+++ b/ahcer/src/app/app-routing.module.ts
@@ -9,7 +9,7 @@ import {LoginComponent} from "./login/login.component";
 import {CreateEpisodeComponent} from "./create-episode/create-episode.component";
 import {ViewEpisodesComponent} from "./view-episodes/view-episodes.component";
 import {ViewMedicationComponent} from "./view-medication/view-medication.component";
-import {redirectUnauthorizedTo} from "@angular/fire/auth-guard";
+import {redirectUnauthorizedTo, redirectLoggedInTo} from "@angular/fire/auth-guard";
 import {AuthPipeGenerator, canActivate} from '@angular/fire/compat/auth-guard';
 import {HelpComponent} from "./help/help.component";
 import { UserIdResolver } from "./services/user-id.resolver";
@@ -19,6 +19,7 @@ import {EpisodeReportComponent} from "./episode-report/episode-report.component"
 
 
 const redirectUnauthorizedToLogin: AuthPipeGenerator = () => redirectUnauthorizedTo(['login']);
+const redirectLoggedInToHome: AuthPipeGenerator = () => redirectLoggedInTo(['']);
 
 function customPayload(title: string, authPipe?: AuthPipeGenerator) {
   let payload: {canActivate?: any[], data: {title?: string, authGuardPipe?: AuthPipeGenerator}} = {data: { }};
@@ -68,7 +69,7 @@ const routes: Routes = [
   {
     path: 'login',
     component: LoginComponent,
-    ...customPayload("Login")
+    ...customPayload("Login", redirectLoggedInToHome)
   },
   {
     path: 'record-episode',

--- a/ahcer/src/app/app-routing.module.ts
+++ b/ahcer/src/app/app-routing.module.ts
@@ -10,7 +10,7 @@ import {CreateEpisodeComponent} from "./create-episode/create-episode.component"
 import {ViewEpisodesComponent} from "./view-episodes/view-episodes.component";
 import {ViewMedicationComponent} from "./view-medication/view-medication.component";
 import {redirectUnauthorizedTo} from "@angular/fire/auth-guard";
-import { canActivate } from '@angular/fire/compat/auth-guard';
+import {AuthPipeGenerator, canActivate} from '@angular/fire/compat/auth-guard';
 import {HelpComponent} from "./help/help.component";
 import { UserIdResolver } from "./services/user-id.resolver";
 import {PrivacyPolicyComponent} from "./privacy-policy/privacy-policy.component";
@@ -18,36 +18,39 @@ import {EpisodeReportComponent} from "./episode-report/episode-report.component"
 
 
 
-const redirectUnauthorizedToLogin = () => redirectUnauthorizedTo(['login']);
+const redirectUnauthorizedToLogin: AuthPipeGenerator = () => redirectUnauthorizedTo(['login']);
 
+function customPayload(title: string, authPipe?: AuthPipeGenerator) {
+  let payload: {canActivate?: any[], data: {title?: string, authGuardPipe?: AuthPipeGenerator}} = {data: { }};
+  if(authPipe) {
+    payload = canActivate(authPipe);
+  }
+  payload.data.title = title;
+  return payload;
+}
 
 const routes: Routes = [
 
   { path: '',
     component: HomeComponent,
-    ...canActivate(redirectUnauthorizedToLogin)
+    ...customPayload("Home", redirectUnauthorizedToLogin)
   },
   {
     path: 'patients',
     component: ViewPatientComponent,
-    ...canActivate(redirectUnauthorizedToLogin)
+    ...customPayload("Patient Listing", redirectUnauthorizedToLogin)
 
   },
   {
     path: 'add-patient',
     component: CreatePatientComponent,
-    ...canActivate(redirectUnauthorizedToLogin)
+    ...customPayload("Add Patient", redirectUnauthorizedToLogin)
 
   },
   {
     path: 'about',
-    component: AboutComponent
-  },
-  {
-    path: 'add-patient',
-    component: CreatePatientComponent,
-    ...canActivate(redirectUnauthorizedToLogin)
-
+    component: AboutComponent,
+    ...customPayload("About")
   },
   {
     path: 'view-profile',
@@ -55,45 +58,42 @@ const routes: Routes = [
     resolve: {
       userId: UserIdResolver,
     },
-    ...canActivate(redirectUnauthorizedToLogin)
+    ...customPayload("User Profile", redirectUnauthorizedToLogin)
   },
   {
     path: 'help',
     component: HelpComponent,
-    ...canActivate(redirectUnauthorizedToLogin)
-  },
-  {
-    path: 'patients',
-    component: ViewPatientComponent,
-    ...canActivate(redirectUnauthorizedToLogin)
+    ...customPayload("Help", redirectUnauthorizedToLogin)
   },
   {
     path: 'login',
-    component: LoginComponent
+    component: LoginComponent,
+    ...customPayload("Login")
   },
   {
     path: 'record-episode',
     component: CreateEpisodeComponent,
-    ...canActivate(redirectUnauthorizedToLogin)
+    ...customPayload("Record Episode", redirectUnauthorizedToLogin)
   },
   {
     path: 'episodes',
     component: ViewEpisodesComponent,
-    ...canActivate(redirectUnauthorizedToLogin)
+    ...customPayload("Episode Listing", redirectUnauthorizedToLogin)
   },
   {
     path: 'medications',
     component: ViewMedicationComponent,
-    ...canActivate(redirectUnauthorizedToLogin)
+    ...customPayload("Manage Medications", redirectUnauthorizedToLogin)
   },
   {
     path: 'episode-report',
     component: EpisodeReportComponent,
-   ...canActivate(redirectUnauthorizedToLogin)
+   ...customPayload("Episode Report", redirectUnauthorizedToLogin)
   },
   {
     path: 'privacy-policy',
-    component: PrivacyPolicyComponent
+    component: PrivacyPolicyComponent,
+    ...customPayload("Privacy Policy")
   }
 ];
 

--- a/ahcer/src/app/app.component.ts
+++ b/ahcer/src/app/app.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 import packageJson from '../../package.json';
 import {UsersService} from "./services/users.service";
+import {ActivatedRoute, NavigationEnd, Router} from "@angular/router";
+import {Title} from "@angular/platform-browser";
+import {filter, map} from "rxjs";
 
 @Component({
   selector: 'app-root',
@@ -9,8 +12,37 @@ import {UsersService} from "./services/users.service";
 })
 export class AppComponent {
   public version: string = packageJson.version;
-  constructor(public user: UsersService) {
+  public appTitle: string = "E-AHC";
+
+  constructor(public user: UsersService,
+              private router: Router,
+              private activatedRoute: ActivatedRoute,
+              private titleService: Title) {
+    this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd),
+      map(() => {
+        let child = this.activatedRoute.firstChild;
+        while (child) {
+          if (child.firstChild) {
+            child = child.firstChild;
+          } else if (child.snapshot.data && child.snapshot.data['title']) {
+            return child.snapshot.data['title'];
+          } else {
+            return null;
+          }
+        }
+        return null;
+      })
+    ).subscribe( (pageTitle: any) => {
+      if (pageTitle) {
+        this.titleService.setTitle(`${pageTitle} | ${this.appTitle}`);
+      }
+      else {
+        this.titleService.setTitle(this.appTitle);
+      }
+    });
   }
+
   public uid = this.user.userId$.subscribe((results) => this.uid = results)
 
   logout() {

--- a/ahcer/src/app/services/users.service.ts
+++ b/ahcer/src/app/services/users.service.ts
@@ -46,8 +46,9 @@ export class UsersService {
   }
 
   logout() {
-    this.afAuth.signOut();
-    this.router.navigateByUrl('/login');
+    this.afAuth.signOut().then(
+      () => this.router.navigateByUrl('/login')
+    );
   }
 
 }

--- a/ahcer/src/index.html
+++ b/ahcer/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Ahcer</title>
+  <title>E-AHC</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
### What I Added/Changed
1. I made the page title tag change based on the route the user visits. For example, the home page now shows "Home | E-AHC" as the title on the browser tab.  This means that the users will now be able to navigate better through the app.
2. I made the app redirect users who access invalid links to the home page. The logged-in users will stay on home page, while the app further redirects the unauthorized users to login page.
3. I also made it redirect logged-in users to home when they access the login page.

### How to Test
1. Visit all the available pages on the app, and make sure that each of the pages has a title that describes it on the browser tab.
2. Type an invalid route link, and check if you are redirected to the home page in case you are logged in. If you are not, make sure you are redirected to the login page.
3. Try accessing the /login route while you are logged in, and see if you are redirected to the home page.
4. I found this bug while testing my commits: I was not redirected to login page when I logged out from home. Try logging out in home page, and see if you are logged out AND redirected to login page.