### PR TITLE
Sign in flow changed to "Pop up" Method

### DIFF
--- a/ahcer/src/app/app.module.ts
+++ b/ahcer/src/app/app.module.ts
@@ -64,7 +64,7 @@ import {MatExpansionModule} from "@angular/material/expansion";
 import {firebase, firebaseui, FirebaseUIModule} from 'firebaseui-angular';
 
 const firebaseUiAuthConfig: firebaseui.auth.Config = {
-  signInFlow: 'redirect',
+  signInFlow: 'popup',
   signInOptions: [
     {
       requireDisplayName: false,


### PR DESCRIPTION
### What I changed
Insert text from the title here. (This is the first attempt to fix iOS log in issues.)

### How to Test
Check to see if a window pops up in the PC browser that gives the log in information for Google. On the phone, a new tab should open. After merging, building, and deploying, please check if you can log in with Google from an iOS device. 